### PR TITLE
Docs: removed git hub API footer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_action :repo_info, only: %i[index show edit new]
+  # before_action :repo_info, only: %i[index show edit new]
 
   def repo_info
     @repo_info = GithubFacade.create_repo

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
     <% end %>
     <div class="container">
       <%= yield %>
-      <%= render partial: "shared/github_footer"%>
+      <%# <%= render partial: "shared/github_footer"%> %>
     </div>
   </body>
 </html>


### PR DESCRIPTION
### What does this PR do?
- creates the relationships and model for bulk discounts, and removes the git hub API footer render.

### Does this PR break anything?
- [ ] Yes
- [x ] No
- If yes, explain:
